### PR TITLE
Format args

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,3 +42,27 @@ include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+find_package(GTest QUIET)
+if(GTest_FOUND)
+  enable_testing()
+  message(STATUS "GTest_FOUND: ${GTest_FOUND}")
+  message(STATUS "TEST_SRC: ${TEST_SRC}")
+  message(STATUS "LIB_SRC: ${LIB_SRC}")
+
+  file(GLOB_RECURSE LIB_SRC formatter/src/**.cpp)
+  list(FILTER LIB_SRC EXCLUDE REGEX ".*/main\\.cpp$")
+
+  add_library(verihogg-format-lib STATIC ${LIB_SRC})
+  target_include_directories(verihogg-format-lib PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/formatter/include>)
+  target_link_libraries(verihogg-format-lib PUBLIC slang::slang)
+
+  file(GLOB_RECURSE TEST_SRC formatter/tests/**.cpp)
+  if(TEST_SRC)
+    add_executable(verihogg-tests ${TEST_SRC})
+    target_link_libraries(verihogg-tests PRIVATE verihogg-format-lib GTest::gtest GTest::gtest_main)
+    include(GoogleTest)
+    gtest_discover_tests(verihogg-tests)
+  endif()
+endif()
+

--- a/formatter/include/cli/format_args.h
+++ b/formatter/include/cli/format_args.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <slang/driver/Driver.h>
+
+#include <utility>
+
+#include "data/format_style.h"
+
+namespace format {
+
+class FormatArgsBinder {
+ public:
+  explicit FormatArgsBinder(slang::driver::Driver& driver);
+  [[nodiscard]] auto buildStyle() -> std::pair<FormatStyle, RunConfig>;
+
+ private:
+  std::optional<uint32_t> column_limit_;
+  std::optional<uint32_t> indentation_spaces_;
+  std::optional<uint32_t> wrap_spaces_;
+  std::optional<uint32_t> line_break_penalty_;
+  std::optional<uint32_t> over_column_limit_penalty_;
+  std::optional<std::string> line_terminator_;
+  std::optional<bool> inplace_;
+};
+
+}  // namespace format

--- a/formatter/include/data/format_style.h
+++ b/formatter/include/data/format_style.h
@@ -1,17 +1,60 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
 
 namespace format {
 
 using ColumnNumber = size_t;
 using IndentLevel = size_t;
 
-struct FormatStyle {
-  ColumnNumber column_limit;
-  IndentLevel indentation_spaces;
+enum class LineTerminator : uint8_t {
+  kAuto,  // определить по исходнику
+  kLf,    // \n
+  kCrLf,  // \r\n
+};
 
-  static auto defaults() noexcept -> FormatStyle;
+[[nodiscard]] inline auto lineTerminatorFromString(std::string_view s)
+    -> LineTerminator {
+  if (s == "lf") {
+    return LineTerminator::kLf;
+  }
+  if (s == "crlf") {
+    return LineTerminator::kCrLf;
+  }
+  if (s == "auto") {
+    return LineTerminator::kAuto;
+  }
+  throw std::invalid_argument(
+      std::string("Unknown --line_terminator: ").append(s));
+}
+
+struct RunConfig {
+  bool inplace = false;
+  std::string stdin_name = "<stdin>";
+  std::vector<std::string> input_files;
+};
+
+namespace defaults {
+inline constexpr ColumnNumber kColumnLimit = 100;
+inline constexpr IndentLevel kIndentationSpaces = 2;
+inline constexpr IndentLevel kWrapSpaces = 4;
+inline constexpr size_t kLineBreakPenalty = 2;
+inline constexpr size_t kOverColumnLimitPenalty = 100;
+}  // namespace defaults
+
+struct FormatStyle {
+  ColumnNumber column_limit = defaults::kColumnLimit;
+  IndentLevel indentation_spaces = defaults::kIndentationSpaces;
+  IndentLevel wrap_spaces = defaults::kWrapSpaces;
+  size_t line_break_penalty = defaults::kLineBreakPenalty;
+  size_t over_column_limit_penalty = defaults::kOverColumnLimitPenalty;
+  LineTerminator line_terminator = LineTerminator::kAuto;
+
+  [[nodiscard]] static auto defaults() noexcept -> FormatStyle { return {}; }
 };
 
 }  // namespace format

--- a/formatter/src/main.cpp
+++ b/formatter/src/main.cpp
@@ -1,18 +1,42 @@
+#include <slang/driver/Driver.h>
+
 #include <cassert>
-#include <cstddef>
-#include <gsl/span>
-#include <gsl/span_ext>
+#include <exception>
+#include <iostream>
 
+#include "cli/format_args.h"
 #include "data/lex_context.h"
+#include "formatter.h"
 
-auto main(int argc, const char** argv) -> int {
-  assert(argc >= 0);
-  const auto args = gsl::span{argv, static_cast<size_t>(argc)};
-  if (argc < 2) {
+auto main(int argc, char** argv) -> int {
+  try {
+    slang::driver::Driver driver;
+    driver.addStandardArgs();
+
+    format::FormatArgsBinder binder(driver);
+
+    if (!driver.parseCommandLine(argc, argv)) {
+      return 1;
+    }
+
+    auto [style, run] = binder.buildStyle();
+
+    const auto& files = driver.sourceLoader.getFilePaths();
+
+    if (run.inplace && files.empty()) {
+      std::cerr << "Warning: --inplace has no effect when reading from stdin\n";
+    }
+
+    if (files.empty()) {
+      LexContext ctx;
+      auto tokens = ctx.lex_file("<stdin>");
+      auto result = format::format(tokens, style);
+      std::cout << result.formatted_text;
+      return 0;
+    }
+    return 0;
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << "\n";
     return 1;
   }
-
-  LexContext ctx;
-  auto tokens = ctx.lex_file(args[1]);
-  return 0;
 }

--- a/formatter/src/pipeline/format_args.cpp
+++ b/formatter/src/pipeline/format_args.cpp
@@ -1,0 +1,66 @@
+#include "cli/format_args.h"
+
+#include <slang/driver/Driver.h>
+
+#include <utility>
+
+#include "data/format_style.h"
+
+namespace format {
+
+FormatArgsBinder::FormatArgsBinder(slang::driver::Driver& driver) {
+  auto& cl = driver.cmdLine;
+
+  cl.add("--column_limit", column_limit_, "Maximum line length (default: 100)",
+         "<N>");
+
+  cl.add("--indentation_spaces", indentation_spaces_,
+         "Spaces for one indentation level (default: 2)", "<N>");
+
+  cl.add("--wrap_spaces", wrap_spaces_,
+         "Additional indentation when hyphenating a line (default: 4)", "<N>");
+
+  cl.add("--line_break_penalty", line_break_penalty_,
+         "Penalty for each line break (default: 2)", "<N>");
+
+  cl.add("--over_column_limit_penalty", over_column_limit_penalty_,
+         "Penalty for each character beyond column_limit (default: 100)",
+         "<N>");
+
+  cl.add("--line_terminator", line_terminator_,
+         "End of line character: auto | lf | crlf (default: auto)", "<mode>");
+  cl.add("--inplace", inplace_,
+         "Overwrite the source files instead of outputting to stdout");
+}
+
+auto FormatArgsBinder::buildStyle() -> std::pair<FormatStyle, RunConfig> {
+  FormatStyle s = FormatStyle::defaults();
+
+  if (column_limit_.has_value()) {
+    s.column_limit = *column_limit_;
+  }
+  if (indentation_spaces_.has_value()) {
+    s.indentation_spaces = *indentation_spaces_;
+  }
+  if (wrap_spaces_.has_value()) {
+    s.wrap_spaces = *wrap_spaces_;
+  }
+  if (line_break_penalty_.has_value()) {
+    s.line_break_penalty = *line_break_penalty_;
+  }
+  if (over_column_limit_penalty_.has_value()) {
+    s.over_column_limit_penalty = *over_column_limit_penalty_;
+  }
+  if (line_terminator_.has_value()) {
+    s.line_terminator = lineTerminatorFromString(*line_terminator_);
+  }
+
+  RunConfig run;
+  if (inplace_.has_value()) {
+    run.inplace = *inplace_;
+  }
+
+  return {s, run};
+}
+
+}  // namespace format

--- a/formatter/tests/format_args_test.cpp
+++ b/formatter/tests/format_args_test.cpp
@@ -1,0 +1,216 @@
+#include "cli/format_args.h"
+
+#include <gtest/gtest.h>
+
+#include "data/format_style.h"
+
+namespace {
+class FormatArgsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    driver.addStandardArgs();
+    binder.emplace(driver);
+  }
+
+  [[nodiscard]] auto parse(std::vector<const char*> args) -> bool {
+    args.insert(args.begin(), "formatter");
+    return driver.parseCommandLine(static_cast<int>(args.size()), args.data());
+  }
+
+  [[nodiscard]] auto buildStyle(std::vector<const char*> args = {})
+      -> std::pair<format::FormatStyle, format::RunConfig> {
+    EXPECT_TRUE(parse(std::move(args)));
+    return binder->buildStyle();
+  }
+
+  template <typename Exception>
+  auto expectBuildStyleThrows() -> void {
+    EXPECT_THROW(std::ignore = binder->buildStyle(), Exception);
+  }
+
+ private:
+  slang::driver::Driver driver;
+  std::optional<format::FormatArgsBinder> binder;
+};
+
+// ---------------------------------------------------------------------------
+// Дефолтные значения
+// ---------------------------------------------------------------------------
+
+TEST_F(FormatArgsTest, DefaultsAreApplied) {
+  auto [style, run] = buildStyle();
+
+  EXPECT_EQ(style.column_limit, format::defaults::kColumnLimit);
+  EXPECT_EQ(style.indentation_spaces, format::defaults::kIndentationSpaces);
+  EXPECT_EQ(style.wrap_spaces, format::defaults::kWrapSpaces);
+  EXPECT_EQ(style.line_break_penalty, format::defaults::kLineBreakPenalty);
+  EXPECT_EQ(style.over_column_limit_penalty,
+            format::defaults::kOverColumnLimitPenalty);
+  EXPECT_EQ(style.line_terminator, format::LineTerminator::kAuto);
+  EXPECT_FALSE(run.inplace);
+}
+
+TEST_F(FormatArgsTest, CustomColumnLimit) {
+  auto [style, run] = buildStyle({"--column_limit", "120"});
+
+  EXPECT_EQ(style.column_limit, 120U);
+  EXPECT_EQ(style.indentation_spaces, format::defaults::kIndentationSpaces);
+  EXPECT_EQ(style.wrap_spaces, format::defaults::kWrapSpaces);
+  EXPECT_EQ(style.line_break_penalty, format::defaults::kLineBreakPenalty);
+  EXPECT_EQ(style.over_column_limit_penalty,
+            format::defaults::kOverColumnLimitPenalty);
+  EXPECT_FALSE(run.inplace);
+}
+
+TEST_F(FormatArgsTest, CustomIndentationSpaces) {
+  auto [style, run] = buildStyle({"--indentation_spaces", "4"});
+
+  EXPECT_EQ(style.indentation_spaces, 4U);
+  EXPECT_EQ(style.column_limit, format::defaults::kColumnLimit);
+  EXPECT_EQ(style.wrap_spaces, format::defaults::kWrapSpaces);
+}
+
+TEST_F(FormatArgsTest, CustomWrapSpaces) {
+  auto [style, run] = buildStyle({"--wrap_spaces", "8"});
+
+  EXPECT_EQ(style.wrap_spaces, 8U);
+  EXPECT_EQ(style.column_limit, format::defaults::kColumnLimit);
+  EXPECT_EQ(style.indentation_spaces, format::defaults::kIndentationSpaces);
+}
+
+TEST_F(FormatArgsTest, CustomLineBreakPenalty) {
+  auto [style, run] = buildStyle({"--line_break_penalty", "10"});
+
+  EXPECT_EQ(style.line_break_penalty, 10U);
+  EXPECT_EQ(style.over_column_limit_penalty,
+            format::defaults::kOverColumnLimitPenalty);
+}
+
+TEST_F(FormatArgsTest, CustomOverColumnLimitPenalty) {
+  auto [style, run] = buildStyle({"--over_column_limit_penalty", "50"});
+
+  EXPECT_EQ(style.over_column_limit_penalty, 50U);
+  EXPECT_EQ(style.line_break_penalty, format::defaults::kLineBreakPenalty);
+}
+
+// ---------------------------------------------------------------------------
+// Флаг --inplace
+// ---------------------------------------------------------------------------
+
+TEST_F(FormatArgsTest, InplaceFlagSetsRunConfig) {
+  auto [style, run] = buildStyle({"--inplace"});
+
+  EXPECT_TRUE(run.inplace);
+  // --inplace не должен влиять на стиль форматирования.
+  EXPECT_EQ(style.column_limit, format::defaults::kColumnLimit);
+  EXPECT_EQ(style.indentation_spaces, format::defaults::kIndentationSpaces);
+}
+
+// ---------------------------------------------------------------------------
+// --line_terminator: все три допустимых значения
+// ---------------------------------------------------------------------------
+
+TEST_F(FormatArgsTest, LineTerminatorAuto) {
+  auto [style, run] = buildStyle({"--line_terminator", "auto"});
+  EXPECT_EQ(style.line_terminator, format::LineTerminator::kAuto);
+}
+
+TEST_F(FormatArgsTest, LineTerminatorLf) {
+  auto [style, run] = buildStyle({"--line_terminator", "lf"});
+  EXPECT_EQ(style.line_terminator, format::LineTerminator::kLf);
+}
+
+TEST_F(FormatArgsTest, LineTerminatorCrlf) {
+  auto [style, run] = buildStyle({"--line_terminator", "crlf"});
+  EXPECT_EQ(style.line_terminator, format::LineTerminator::kCrLf);
+}
+
+TEST_F(FormatArgsTest, InvalidLineTerminatorThrows) {
+  // parseCommandLine принимает строку как есть - исключение бросает buildStyle.
+  ASSERT_TRUE(parse({"--line_terminator", "windows"}));
+  expectBuildStyleThrows<std::invalid_argument>();
+}
+
+TEST_F(FormatArgsTest, EmptyLineTerminatorThrows) {
+  ASSERT_TRUE(parse({"--line_terminator", ""}));
+  expectBuildStyleThrows<std::invalid_argument>();
+}
+
+// ---------------------------------------------------------------------------
+// Несколько флагов одновременно - независимость друг от друга
+// ---------------------------------------------------------------------------
+
+TEST_F(FormatArgsTest, MultipleNumericFlagsAreIndependent) {
+  auto [style, run] = buildStyle({
+      "--column_limit",
+      "80",
+      "--indentation_spaces",
+      "4",
+      "--wrap_spaces",
+      "8",
+      "--line_break_penalty",
+      "5",
+      "--over_column_limit_penalty",
+      "200",
+      "--line_terminator",
+      "lf",
+      "--inplace",
+  });
+
+  EXPECT_EQ(style.column_limit, 80U);
+  EXPECT_EQ(style.indentation_spaces, 4U);
+  EXPECT_EQ(style.wrap_spaces, 8U);
+  EXPECT_EQ(style.line_break_penalty, 5U);
+  EXPECT_EQ(style.over_column_limit_penalty, 200U);
+  EXPECT_EQ(style.line_terminator, format::LineTerminator::kLf);
+  EXPECT_TRUE(run.inplace);
+}
+
+// ---------------------------------------------------------------------------
+// Граничные значения числовых флагов
+// ---------------------------------------------------------------------------
+
+TEST_F(FormatArgsTest, ColumnLimitOfOne) {
+  // Значение 1 технически допустимо на уровне CLI - бизнес-логика проверяет
+  // корректность отдельно, парсер не должен отвергать.
+  auto [style, run] = buildStyle({"--column_limit", "1"});
+  EXPECT_EQ(style.column_limit, 1U);
+}
+
+TEST_F(FormatArgsTest, LargeColumnLimit) {
+  // slang парсит числовые аргументы как uint32_t, поэтому верхняя граница -
+  // numeric_limits<uint32_t>::max(), а не size_t.
+  constexpr auto kMax = std::numeric_limits<uint32_t>::max();
+  auto [style, run] =
+      buildStyle({"--column_limit", std::to_string(kMax).c_str()});
+  EXPECT_EQ(style.column_limit, kMax);
+}
+TEST_F(FormatArgsTest, ZeroIndentationSpaces) {
+  auto [style, run] = buildStyle({"--indentation_spaces", "0"});
+  EXPECT_EQ(style.indentation_spaces, 0U);
+}
+
+TEST_F(FormatArgsTest, ColumnLimitOfZeroAcceptedByParser) {
+  // Ноль не имеет смысла семантически, но парсер не должен его отвергать -
+  // валидация значений - ответственность бизнес-логики.
+  auto [style, run] = buildStyle({"--column_limit", "0"});
+  EXPECT_EQ(style.column_limit, 0U);
+}
+
+// ---------------------------------------------------------------------------
+// Невалидный числовой флаг - parseCommandLine должен вернуть false.
+// ---------------------------------------------------------------------------
+
+TEST_F(FormatArgsTest, NonNumericColumnLimitRejectedByParser) {
+  EXPECT_FALSE(parse({"--column_limit", "abc"}));
+}
+
+TEST_F(FormatArgsTest, NegativeColumnLimitRejectedByParser) {
+  EXPECT_FALSE(parse({"--column_limit", "-1"}));
+}
+
+TEST_F(FormatArgsTest, UnknownFlagRejectedByParser) {
+  EXPECT_FALSE(parse({"--unknown_flag"}));
+}
+
+}  // namespace

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -5,6 +5,7 @@
   ] ++ sv-lang.buildInputs;
 
   nativeBuildInputs = with pkgs; [
+    gtest
     cmake
     ninja
     pkg-config


### PR DESCRIPTION
## CLI argument parsing

Реализован парсинг аргументов командной строки для форматтера.

### Изменения

- **`format_args`** — привязка флагов `--column_limit`, `--indentation_spaces`, `--wrap_spaces`, `--line_break_penalty`, `--over_column_limit_penalty`, `--line_terminator`, `--inplace` через slang `Driver::cmdLine`; сборка `FormatStyle` и `RunConfig` в `buildStyle()`
- **`format_style`** — добавлены поля и дефолты для всех параметров форматирования, `lineTerminatorFromString` для парсинга значения `--line_terminator`
- **`main`** — подключён `FormatArgsBinder`, добавлена обработка флага `--inplace` при чтении из stdin
- **`format_args_test`** — покрыты дефолты, каждый флаг по отдельности, все значения `--line_terminator`, граничные значения числовых аргументов, невалидный ввод